### PR TITLE
#4 Add Android Flask server for clipboard sync with AES encryption

### DIFF
--- a/android_flask_server.py
+++ b/android_flask_server.py
@@ -1,0 +1,38 @@
+import os
+import json
+import base64
+from flask import Flask, request, jsonify
+from Crypto.Cipher import AES
+import subprocess
+
+# Load config from shared/config.json
+with open('shared/config.json', 'r') as f:
+    config = json.load(f)
+
+AES_KEY = base64.b64decode(config['aes_key'])
+AES_IV = base64.b64decode(config['iv'])
+LOCAL_PORT = config['local_port']
+
+app = Flask(__name__)
+
+@app.route('/clipboard', methods=['POST'])
+def clipboard():
+    data = request.get_json()
+    if not data or 'data' not in data:
+        return jsonify({"error": "Missing 'data' field"}), 400
+    try:
+        encrypted = base64.b64decode(data['data'])
+        cipher = AES.new(AES_KEY, AES.MODE_CBC, AES_IV)
+        decrypted = cipher.decrypt(encrypted)
+        pad_len = decrypted[-1]
+        clipboard_text = decrypted[:-pad_len].decode('utf-8')
+        # Set clipboard using Termux:API
+        subprocess.run(['termux-clipboard-set', clipboard_text])
+        print(f"Clipboard updated: {clipboard_text}")
+        return jsonify({"status": "success"}), 200
+    except Exception as e:
+        print(f"Error: {e}")
+        return jsonify({"error": str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=LOCAL_PORT)


### PR DESCRIPTION
## Android Flask Server for Clipboard Sync Issue no - 4

This PR adds a Flask server for Android (Termux) that:
- Receives encrypted clipboard data via the /clipboard endpoint
- Decrypts with AES (key/IV from config.json)
- Updates the Android clipboard using termux-api
- Includes setup instructions and test examples

### Proof of Functionality

**Laptop CMD:**
![WhatsApp Image 2025-07-03 at 14 47 59_0d1f5027](https://github.com/user-attachments/assets/e1c5d3dc-dc85-483c-bac4-e087bd40ce13)


**Termux (Phone):**
![WhatsApp Image 2025-07-03 at 14 57 36_39708219](https://github.com/user-attachments/assets/46516143-ef80-4d80-9623-9ad05ccadfbe)


See README for setup and usage.
